### PR TITLE
Added T6500 to check_features.cpp whitelist

### DIFF
--- a/src/anbox/cmds/check_features.cpp
+++ b/src/anbox/cmds/check_features.cpp
@@ -44,6 +44,8 @@ std::vector<std::string> cpu_whitelist = {
   "Q 720",
   // Intel Xeon E5520
   "E5520"
+  // Intel Core2 Duo T6500
+  "T6500"
 };
 } // namespace
 


### PR DESCRIPTION
Tried --edge and --beta snap installs with no success.

Added [T6500](http://www.cpu-world.com/CPUs/Core_2/Intel-Core%202%20Duo%20Mobile%20T6500%20AW80577GG0452MA%20-%20AW80577GG0452ML.html) processor to whitelist, which has SSE 4.1 support.